### PR TITLE
Updated to work with a more recent version of rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 [dependencies]
 serde_cbor = {version = "0.11" }
 serde = "1.0"
-rustls = { version = "0.16", features = [ "dangerous_configuration" ] }
-webpki = "0.21.2"
+rustls = { version = "0.20.4", features = [ "dangerous_configuration" ] }
+webpki = "0.22.0"
 byteorder = "1.3.4"
 serde_with = { version = "1.9.4", default_features = false }
 aws-nitro-enclaves-cose = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,8 @@ edition = "2018"
 [dependencies]
 serde_cbor = {version = "0.11" }
 serde = "1.0"
-#rustls = { version = "0.18", features = [ "dangerous_configuration" ] }
-rustls = { git = "https://github.com/veracruz-project/rustls.git", features = [ "dangerous_configuration"], branch = "veracruz" }
-webpki = { git = "https://github.com/veracruz-project/webpki.git", branch = "veracruz" }
+rustls = { version = "0.16", features = [ "dangerous_configuration" ] }
+webpki = "0.21.2"
 byteorder = "1.3.4"
 serde_with = { version = "=1.9.4", default_features = false }
 aws-nitro-enclaves-cose = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ serde = "1.0"
 rustls = { version = "0.16", features = [ "dangerous_configuration" ] }
 webpki = "0.21.2"
 byteorder = "1.3.4"
-serde_with = { version = "=1.9.4", default_features = false }
+serde_with = { version = "1.9.4", default_features = false }
 aws-nitro-enclaves-cose = "0.1.0"
 openssl = "0.10.31"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ impl AttestationDocument {
             })?;
 
         let verifier = rustls::server::AllowAnyAuthenticatedClient::new(root_store);
-        let _verified = verifier.verify_client_cert(&rustls::Certificate(document.certificate.clone()), &certs[..], std::time::SystemTime::now()).map_err(|err| {
+        let _verified = verifier.verify_client_cert(&rustls::Certificate(document.certificate.clone()), &certs, std::time::SystemTime::now()).map_err(|err| {
             format!(
                 "AttestationDocument::authenticate verify_client_cert failed:{:?}",
                 err

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,6 @@ impl AttestationDocument {
 
         // Step 3. Verify the certificate's chain
         let mut certs: Vec<rustls::Certificate> = Vec::new();
-        let cert = rustls::Certificate(document.certificate.clone());
-        certs.push(cert);
         for this_cert in document.cabundle.clone().iter().rev() {
             let cert = rustls::Certificate(this_cert.to_vec());
             certs.push(cert);
@@ -71,8 +69,8 @@ impl AttestationDocument {
                 )
             })?;
 
-        let verifier = rustls::AllowAnyAuthenticatedClient::new(root_store);
-        let _verified = verifier.verify_client_cert(&certs).map_err(|err| {
+        let verifier = rustls::server::AllowAnyAuthenticatedClient::new(root_store);
+        let _verified = verifier.verify_client_cert(&rustls::Certificate(document.certificate.clone()), &certs[..], std::time::SystemTime::now()).map_err(|err| {
             format!(
                 "AttestationDocument::authenticate verify_client_cert failed:{:?}",
                 err


### PR DESCRIPTION
This branch also merge into main the changes done in `veracruz-v2` (un-pin `serde_with`).